### PR TITLE
Add Service Email Address

### DIFF
--- a/metadata/config/service.json
+++ b/metadata/config/service.json
@@ -8,5 +8,6 @@
   "name": "Apply to have your criminal case reviewed",
   "pdfHeading": "CCRC Application",
   "phase": "alpha",
-  "phaseText": "Alpha"
+  "phaseText": "Alpha",
+  "serviceEmailAddress": "overtime@ccrc.gov.uk"
 }


### PR DESCRIPTION
This is to allow the submitted email be sent from the CCRC themselves and therefore receive all emails which are replied to going to the CCRC email address.